### PR TITLE
More optimizations

### DIFF
--- a/src/FileIO/Employee.cs
+++ b/src/FileIO/Employee.cs
@@ -5,7 +5,7 @@ namespace FileIO
     /// <summary>
     /// Employee Record
     /// </summary>
-    public struct Employee 
+    public struct Employee
     {
         /// <summary>
         /// Name of the Employee
@@ -18,7 +18,5 @@ namespace FileIO
         public DateTime DateOfJoining { get; set; }
         public double Salary { get; set; }
         public int Age { get; set; }
-        
-        
     }
 }


### PR DESCRIPTION
- Don't allocate new line based on the platform in ParseLines. Just use \n and trim \r if necessary.
- Don't allocate a string for the line to check if it's the header, just compare bytes.
- Use Utf8Parser to parse the DateOfJoining, Salary and Age instead of converting to a string.