### PR TITLE
Add Sylvan csv benchmark

### DIFF
--- a/src/FileIO/FileIO.csproj
+++ b/src/FileIO/FileIO.csproj
@@ -8,6 +8,7 @@
       <PackageReference Include="CsvHelper" Version="27.1.0" />
       <PackageReference Include="System.IO.Pipelines" Version="5.0.1" />
       <PackageReference Include="System.Linq.Async" Version="5.0.0" />
+      <PackageReference Include="Sylvan.Data.Csv" Version="1.0.3" />
     </ItemGroup>
 
 </Project>

--- a/src/FileIO/WithCsvHelperLib.cs
+++ b/src/FileIO/WithCsvHelperLib.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -9,12 +10,28 @@ namespace FileIO
     public class WithCsvHelperLib
     {
 
-        public  IEnumerable<Employee> ProcessFileAsync(string filePath)
+        public IEnumerable<Employee> ProcessFileAsync(string filePath)
         {
             using var reader = new StreamReader(filePath);
+
+            Employee[] employees = new Employee[100000];
             using var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
-            var records = csv.GetRecords<Employee>();
-            return records.ToList();
+            int idx = 0;
+            csv.Read();
+            while (csv.Read())
+            {
+                var emp = new Employee
+                {
+                    Name = csv[0],
+                    Email = csv[1],
+                    DateOfJoining = DateTime.Parse(csv[2]),
+                    Salary = double.Parse(csv[3]),
+                    Age = int.Parse(csv[4]),
+                };
+                employees[idx++] = emp;
+
+            }
+            return employees;
 
         }
     }

--- a/src/FileIO/WithSylvanLib.cs
+++ b/src/FileIO/WithSylvanLib.cs
@@ -1,6 +1,8 @@
 using System.IO;
 using Sylvan.Data.Csv;
 using System.Buffers;
+using System.Threading.Tasks;
+using System.Text;
 
 namespace FileIO
 {
@@ -8,13 +10,37 @@ namespace FileIO
     {
         public void ProcessFile(string filePath, Employee[] employeeRecords)
         {
-            using var reader = new StreamReader(filePath);
+            const int BufferSize = 0x10000;
+            using var reader = new StreamReader(filePath, Encoding.UTF8, false, BufferSize);
 
-            char[] buffer = ArrayPool<char>.Shared.Rent(0x10000);
+            char[] buffer = ArrayPool<char>.Shared.Rent(BufferSize);
 
             using var csv = CsvDataReader.Create(reader, new CsvDataReaderOptions { Buffer = buffer });
             int idx = 0;
             while (csv.Read())
+            {
+                employeeRecords[idx++] = new Employee
+                {
+                    Name = csv.GetString(0),
+                    Email = csv.GetString(1),
+                    DateOfJoining = csv.GetDateTime(2),
+                    Salary = csv.GetDouble(3),
+                    Age = csv.GetInt32(4),
+                };
+            }
+            ArrayPool<char>.Shared.Return(buffer);
+        }
+
+        public async Task ProcessFileAsync(string filePath, Employee[] employeeRecords)
+        {
+            const int BufferSize = 0x10000;
+            using var reader = new StreamReader(filePath, Encoding.UTF8, false, BufferSize);
+
+            char[] buffer = ArrayPool<char>.Shared.Rent(BufferSize);
+
+            await using var csv = await CsvDataReader.CreateAsync(reader, new CsvDataReaderOptions { Buffer = buffer });
+            int idx = 0;
+            while (await csv.ReadAsync())
             {
                 employeeRecords[idx++] = new Employee
                 {

--- a/src/FileIO/WithSylvanLib.cs
+++ b/src/FileIO/WithSylvanLib.cs
@@ -1,0 +1,31 @@
+using System.IO;
+using Sylvan.Data.Csv;
+using System.Buffers;
+
+namespace FileIO
+{
+    public class WithSylvanLib
+    {
+        public void ProcessFile(string filePath, Employee[] employeeRecords)
+        {
+            using var reader = new StreamReader(filePath);
+
+            char[] buffer = ArrayPool<char>.Shared.Rent(0x10000);
+
+            using var csv = CsvDataReader.Create(reader, new CsvDataReaderOptions { Buffer = buffer });
+            int idx = 0;
+            while (csv.Read())
+            {
+                employeeRecords[idx++] = new Employee
+                {
+                    Name = csv.GetString(0),
+                    Email = csv.GetString(1),
+                    DateOfJoining = csv.GetDateTime(2),
+                    Salary = csv.GetDouble(3),
+                    Age = csv.GetInt32(4),
+                };
+            }
+            ArrayPool<char>.Shared.Return(buffer);
+        }
+    }
+}

--- a/tests/FileIO.Benchmarks/FileIOTest.cs
+++ b/tests/FileIO.Benchmarks/FileIOTest.cs
@@ -13,18 +13,11 @@ namespace FileIO.Benchmarks
     [RankColumn()]
     public class FileIOTest
     {
-        private string _filePath;
-        [GlobalSetup]
-        public void Setup()
-        {
-            var directoryPath = Path.GetDirectoryName(Assembly.GetAssembly(typeof(Program))?.Location);
-            _filePath = Path.Combine(directoryPath ?? string.Empty, "Employees.csv");
-        }
+        private string _filePath = "Employees.csv";
+
         [Benchmark]
         public async Task PipeLines()
         {
-           // var directoryPath = Path.GetDirectoryName(Assembly.GetAssembly(typeof(Program))?.Location);
-            //_filePath = Path.Combine(directoryPath ?? string.Empty, "Employees.csv");
             var pool = ArrayPool<Employee>.Shared;
             var employeeRecords = pool.Rent(100000);
             var pipeLinesTest = new WithPipeLines();
@@ -41,19 +34,15 @@ namespace FileIO.Benchmarks
 
         [Benchmark]
         public async Task<IList<Employee>> AsyncStream()
-        { 
-          //  var directoryPath = Path.GetDirectoryName(Assembly.GetAssembly(typeof(Program))?.Location);
-           // _filePath = Path.Combine(directoryPath ?? string.Empty, "Employees.csv");
+        {
             var asyncStream = new WithAsyncStreams();
-           var employees = await asyncStream.ProcessStreamAsync(_filePath);
-           return employees;
+            var employees = await asyncStream.ProcessStreamAsync(_filePath);
+            return employees;
         }
 
         [Benchmark]
         public void CsvHelper()
         {
-          //  var directoryPath = Path.GetDirectoryName(Assembly.GetAssembly(typeof(Program))?.Location);
-            //_filePath = Path.Combine(directoryPath ?? string.Empty, "Employees.csv");
             var csvHelper = new WithCsvHelperLib();
             var employeesList = csvHelper.ProcessFileAsync(_filePath);
 
@@ -62,15 +51,33 @@ namespace FileIO.Benchmarks
         [Benchmark]
         public void Sylvan()
         {
-            var directoryPath = Path.GetDirectoryName(Assembly.GetAssembly(typeof(Program))?.Location);
-            _filePath = Path.Combine(directoryPath ?? string.Empty, "Employees.csv");
             var sylv = new WithSylvanLib();
             var pool = ArrayPool<Employee>.Shared;
             var employeeRecords = pool.Rent(100000);
 
-            try {
+            try
+            {
                 sylv.ProcessFile(_filePath, employeeRecords);
-            } finally {
+            }
+            finally
+            {
+                pool.Return(employeeRecords, true);
+            }
+        }
+
+        [Benchmark]
+        public async Task SylvanAsync()
+        {
+            var sylv = new WithSylvanLib();
+            var pool = ArrayPool<Employee>.Shared;
+            var employeeRecords = pool.Rent(100000);
+
+            try
+            {
+                await sylv.ProcessFileAsync(_filePath, employeeRecords);
+            }
+            finally
+            {
                 pool.Return(employeeRecords, true);
             }
         }

--- a/tests/FileIO.Benchmarks/FileIOTest.cs
+++ b/tests/FileIO.Benchmarks/FileIOTest.cs
@@ -58,5 +58,21 @@ namespace FileIO.Benchmarks
             var employeesList = csvHelper.ProcessFileAsync(_filePath);
 
         }
+
+        [Benchmark]
+        public void Sylvan()
+        {
+            var directoryPath = Path.GetDirectoryName(Assembly.GetAssembly(typeof(Program))?.Location);
+            _filePath = Path.Combine(directoryPath ?? string.Empty, "Employees.csv");
+            var sylv = new WithSylvanLib();
+            var pool = ArrayPool<Employee>.Shared;
+            var employeeRecords = pool.Rent(100000);
+
+            try {
+                sylv.ProcessFile(_filePath, employeeRecords);
+            } finally {
+                pool.Return(employeeRecords, true);
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds my own CSV library, Sylvan.Data.Csv, to the benchmark set.

Current results on my machine:
|      Method |      Mean |    Error |   StdDev | Rank |      Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|------------ |----------:|---------:|---------:|-----:|-----------:|----------:|----------:|----------:|
|      Sylvan |  58.10 ms | 0.411 ms | 0.364 ms |    1 |  2111.1111 | 1000.0000 |  111.1111 |     12 MB |
|   PipeLines |  88.62 ms | 1.672 ms | 1.642 ms |    2 |  3166.6667 | 1166.6667 |  333.3333 |     17 MB |
|   CsvHelper | 178.20 ms | 3.187 ms | 2.981 ms |    3 | 12666.6667 | 4666.6667 | 2000.0000 |     77 MB |
| AsyncStream | 181.59 ms | 3.024 ms | 2.828 ms |    3 | 10333.3333 | 3333.3333 | 1000.0000 |     64 MB |

The pipelines run was previously faster than Sylvan until the most recent changes you added.