### PR TITLE
Use both ends of the pipe in parallel

### DIFF
--- a/tests/FileIO.Benchmarks/FileIOTest.cs
+++ b/tests/FileIO.Benchmarks/FileIOTest.cs
@@ -40,6 +40,23 @@ namespace FileIO.Benchmarks
         }
 
         [Benchmark]
+        public async Task FullPipe()
+        {
+            var pool = ArrayPool<Employee>.Shared;
+            var employeeRecords = pool.Rent(100000);
+            var pipeLinesTest = new WithPipeLines();
+
+            try
+            {
+                await pipeLinesTest.ProcessWithFullPipeAsync(_filePath, employeeRecords);
+            }
+            finally
+            {
+                pool.Return(employeeRecords, clearArray: true);
+            }
+        }
+
+        [Benchmark]
         public async Task<IList<Employee>> AsyncStream()
         { 
           //  var directoryPath = Path.GetDirectoryName(Assembly.GetAssembly(typeof(Program))?.Location);


### PR DESCRIPTION
By splitting the pipe into the writing end and reading end it
seems to be able to slightly boost performance. On my system
it benchmarks as roughly ~10% faster to have the file being
parsed while it is loading in.

``` ini
BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19042.985 (20H2/October2020Update)
AMD Ryzen 7 5800X, 1 CPU, 16 logical and 8 physical cores
.NET SDK=5.0.203
  [Host]     : .NET 5.0.6 (5.0.621.22011), X64 RyuJIT
  DefaultJob : .NET 5.0.6 (5.0.621.22011), X64 RyuJIT

```
|      Method |      Mean |    Error |   StdDev | Rank |     Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|------------ |----------:|---------:|---------:|-----:|----------:|----------:|----------:|----------:|
|    FullPipe |  51.77 ms | 0.363 ms | 0.303 ms |    1 | 1000.0000 |  500.0000 |         - |     17 MB |
|   PipeLines |  56.97 ms | 0.400 ms | 0.355 ms |    2 | 1000.0000 |  444.4444 |         - |     17 MB |
|   CsvHelper | 136.83 ms | 1.827 ms | 1.709 ms |    3 | 5250.0000 | 2250.0000 | 1500.0000 |     77 MB |
| AsyncStream | 153.04 ms | 2.995 ms | 4.483 ms |    4 | 4250.0000 | 2500.0000 |  750.0000 |     64 MB |